### PR TITLE
docs: fix syntax error in contains query filter example (fixes #100)

### DIFF
--- a/docs/cheat_sheet.rst
+++ b/docs/cheat_sheet.rst
@@ -39,7 +39,7 @@ qry = qry.filter(<CONDITION>)
      - Filter a column that are/are not Null
 
    * - :python:`.contains()`
-     - :python:`qry.filter(LayerData.comments).contains('graupel'))`
+     - :python:`qry.filter(LayerData.comments.contains('graupel'))`
      - Filter by finding a substring
 
    * - :python:`.distinct()`


### PR DESCRIPTION
## Summary
Fixes #100.

## Changes
- Fix syntax error in `docs/cheat_sheet.rst` under `.contains()` table entry.
- Corrected `qry.filter(LayerData.comments).contains('graupel'))` to `qry.filter(LayerData.comments.contains('graupel'))`.